### PR TITLE
Import error in back.py

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -11,3 +11,5 @@ from .app import app
 
 from .controllers import *
 from .apis import *
+
+__all__ = ["app"]

--- a/application/utils/back.py
+++ b/application/utils/back.py
@@ -52,5 +52,4 @@ with app.app_context():
         def redirect(default=default_view, cookie=cookie):
             return redirect(back.url(default, cookie))
 
-
     back = Back()

--- a/application/utils/back.py
+++ b/application/utils/back.py
@@ -17,7 +17,8 @@ from functools import wraps
 
 from flask import session, redirect, current_app, request, url_for
 
-from imaginary.server import app
+from ..app import app
+
 
 with app.app_context():
     class Back(object):


### PR DESCRIPTION
From the previous build of imaginary. There exist a small bug in the `application/utils/back.py` file.

```python
from imaginary.server import app
```

has been changed to 

```python
from ..app import app
```